### PR TITLE
Update README: Change npm start to npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ npm install
 
 Start the Development Server
 
-npm start
+npm run dev
 
 Access the App
 Open your browser and navigate to:


### PR DESCRIPTION
Updated the README to reflect the correct command for starting the development server.
- Changed `npm start` to `npm run dev` for accuracy.